### PR TITLE
Add option to download unconfirmed transactions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,6 +11,31 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:401d088d63d37e8da99e1cf7e917a465436a41a143ef16a0a8013873745a2ddd"
+  name = "github.com/btcsuite/btcd"
+  packages = [
+    "btcec",
+    "chaincfg",
+    "chaincfg/chainhash",
+    "wire",
+  ]
+  pruneopts = "UT"
+  revision = "67e573d211ace594f1366b4ce9d39726c4b19bd0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d0a31b77988b04afbfa2c5ee38567a7a35d5a95de2266a644a7bc8d5c898e68d"
+  name = "github.com/btcsuite/btcutil"
+  packages = [
+    ".",
+    "base58",
+    "bech32",
+  ]
+  pruneopts = "UT"
+  revision = "ab6388e0c60ae4834a1f57511e20c17b5f78be4b"
+
+[[projects]]
+  branch = "master"
   digest = "1:1e6b2f7aa98b082c30a1303c29a702c369b2ec6d86b74a599bc8bbe2333db299"
   name = "github.com/btcsuite/go-socks"
   packages = ["socks"]
@@ -88,11 +113,12 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:52c0bca4d1c7d37712d259e17547e649e98c97c4db26d93b8c9ef756f16f2621"
+  digest = "1:7eb4577517abdf0f214f577e4e85c868c3fdf163ed476fe9ba27d676b9536eb8"
   name = "github.com/gcash/bchutil"
   packages = [
     ".",
     "base58",
+    "bloom",
     "gcs",
     "gcs/builder",
     "hdkeychain",
@@ -154,6 +180,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/btcsuite/btcutil",
     "github.com/davecgh/go-spew/spew",
     "github.com/gcash/bchd/addrmgr",
     "github.com/gcash/bchd/bchec",
@@ -169,6 +196,7 @@
     "github.com/gcash/bchd/wire",
     "github.com/gcash/bchlog",
     "github.com/gcash/bchutil",
+    "github.com/gcash/bchutil/bloom",
     "github.com/gcash/bchutil/gcs",
     "github.com/gcash/bchutil/gcs/builder",
     "github.com/gcash/bchwallet/waddrmgr",

--- a/blockmanager.go
+++ b/blockmanager.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"container/list"
 	"fmt"
+	"github.com/gcash/bchutil/bloom"
 	"github.com/go-errors/errors"
 	"math"
 	"math/big"
@@ -87,6 +88,14 @@ type txMsg struct {
 	tx   *bchutil.Tx
 	peer *ServerPeer
 }
+
+// disableTxDownloadMsg tells the peer handler to send a match none
+// bloom filter to all peers
+type disableTxDownloadMsg struct{}
+
+// enableTxDownloadMsg tells the peer handler to send a match all
+//// bloom filter to all peers
+type enableTxDownloadMsg struct{}
 
 // blockManager provides a concurrency safe block manager for handling all
 // incoming blocks.
@@ -175,6 +184,8 @@ type blockManager struct {
 	minRetargetTimespan int64 // target timespan / adjustment factor
 	maxRetargetTimespan int64 // target timespan * adjustment factor
 	blocksPerRetarget   int32 // target timespan / target time per block
+
+	requestedTxns map[chainhash.Hash]struct{}
 }
 
 // newBlockManager returns a new bitcoin block manager.  Use Start to begin
@@ -203,6 +214,7 @@ func newBlockManager(s *ChainService) (*blockManager, error) {
 		blocksPerRetarget:   int32(targetTimespan / targetTimePerBlock),
 		minRetargetTimespan: targetTimespan / adjustmentFactor,
 		maxRetargetTimespan: targetTimespan * adjustmentFactor,
+		requestedTxns:       make(map[chainhash.Hash]struct{}),
 	}
 
 	// Next we'll create the two signals that goroutines will use to wait
@@ -1632,11 +1644,20 @@ out:
 			case *invMsg:
 				b.handleInvMsg(msg)
 
+			case *txMsg:
+				b.handleTxMsg(msg)
+
 			case *headersMsg:
 				b.handleHeadersMsg(msg)
 
 			case *donePeerMsg:
 				b.handleDonePeerMsg(candidatePeers, msg.peer)
+
+			case *disableTxDownloadMsg:
+				b.handleDisableTxDownloadMsg(candidatePeers)
+
+			case *enableTxDownloadMsg:
+				b.handleEnableTxDownloadMsg(candidatePeers)
 
 			default:
 				log.Warnf("Invalid message type in block "+
@@ -1912,13 +1933,48 @@ func (b *blockManager) QueueInv(inv *wire.MsgInv, sp *ServerPeer) {
 	}
 }
 
+/// QueueTx adds the passed transaction message and peer to the block handling
+// queue. Responds to the done channel argument after the tx message is
+// processed.
+func (b *blockManager) QueueTx(tx *bchutil.Tx, sp *ServerPeer) {
+	// No channel handling here because peers do not need to block on inv
+	// messages.
+	if atomic.LoadInt32(&b.shutdown) != 0 {
+		return
+	}
+
+	select {
+	case b.peerChan <- &txMsg{tx: tx, peer: sp}:
+	case <-b.quit:
+		return
+	}
+}
+
 // handleInvMsg handles inv messages from all peers.
 // We examine the inventory advertised by the remote peer and act accordingly.
 func (b *blockManager) handleInvMsg(imsg *invMsg) {
+	invVects := imsg.inv.InvList
+	if b.BlockHeadersSynced() {
+		gdmsg := wire.NewMsgGetData()
+		for _, iv := range invVects {
+			if iv.Type == wire.InvTypeTx {
+				if b.server.mempool.HaveTransaction(&iv.Hash) {
+					continue
+				}
+				if _, exists := b.requestedTxns[iv.Hash]; !exists {
+					b.requestedTxns[iv.Hash] = struct{}{}
+					gdmsg.AddInvVect(iv)
+				}
+			}
+		}
+		if len(gdmsg.InvList) > 0 {
+			imsg.peer.QueueMessage(gdmsg, nil)
+		}
+	}
+
 	// Attempt to find the final block in the inventory list.  There may
 	// not be one.
 	lastBlock := -1
-	invVects := imsg.inv.InvList
 	for i := len(invVects) - 1; i >= 0; i-- {
 		if invVects[i].Type == wire.InvTypeBlock {
 			lastBlock = i
@@ -1993,6 +2049,41 @@ func (b *blockManager) handleInvMsg(imsg *invMsg) {
 			}
 			b.lastRequested = invVects[lastBlock].Hash
 		}
+	}
+}
+
+// handleTxMsg handles transaction messages from all peers.
+func (b *blockManager) handleTxMsg(tmsg *txMsg) {
+	txHash := tmsg.tx.Hash()
+	if _, exists := b.requestedTxns[*txHash]; !exists {
+		log.Warnf("Peer %s sent us a transaction we didn't request", tmsg.peer.Addr())
+		return
+	}
+	b.server.mempool.AddTransaction(tmsg.tx)
+	delete(b.requestedTxns, *txHash)
+}
+
+// handleDisableTxDownloadMsg sends a match none bloom filter to all peers
+func (b *blockManager) handleDisableTxDownloadMsg(peers *list.List) {
+	for e := peers.Front(); e != nil; e = e.Next() {
+		sp, ok := e.Value.(*ServerPeer)
+		if !ok {
+			log.Error("handleDisableTxDownloadMsg error asserting type ServerPeer")
+		}
+		filter := bloom.NewFilter(0, 0, 0, wire.BloomUpdateNone)
+		sp.QueueMessage(filter.MsgFilterLoad(), nil)
+	}
+}
+
+// handleEnableTxDownloadMsg sends a match all bloom filter to all peers
+func (b *blockManager) handleEnableTxDownloadMsg(peers *list.List) {
+	for e := peers.Front(); e != nil; e = e.Next() {
+		sp, ok := e.Value.(*ServerPeer)
+		if !ok {
+			log.Error("handleEnableTxDownloadMsg error asserting type ServerPeer")
+		}
+		filter := bloom.NewFilter(0, 0, 1, wire.BloomUpdateNone)
+		sp.QueueMessage(filter.MsgFilterLoad(), nil)
 	}
 }
 
@@ -2353,6 +2444,10 @@ func (b *blockManager) handleHeadersMsg(hmsg *headersMsg) {
 	b.headerTipHash = *finalHash
 	b.newHeadersMtx.Unlock()
 	b.newHeadersSignal.Broadcast()
+
+	// Clear the mempool to free up memory. This may mean we might receive
+	// transactions we've previously downloaded but this is rather unlikely.
+	b.server.mempool.Clear()
 }
 
 // checkHeaderSanity checks the PoW, and timestamp of a block header.

--- a/mempool.go
+++ b/mempool.go
@@ -1,0 +1,73 @@
+package neutrino
+
+import (
+	"github.com/gcash/bchd/btcjson"
+	"github.com/gcash/bchd/chaincfg/chainhash"
+	"github.com/gcash/bchutil"
+	"sync"
+)
+
+// Mempool is used when we are downloading unconfirmed transactions.
+// We will use this object to track which transactions we've already
+// downloaded so that we don't download them more than once.
+type Mempool struct {
+	downloadedTxs map[chainhash.Hash]bool
+	mtx           sync.RWMutex
+	callbacks     []func(tx *bchutil.Tx, block *btcjson.BlockDetails)
+	watchedAddrs  []bchutil.Address
+}
+
+// NewMempool returns an initialized mempool
+func NewMempool() *Mempool {
+	return &Mempool{
+		downloadedTxs: make(map[chainhash.Hash]bool),
+		mtx:           sync.RWMutex{},
+	}
+}
+
+// RegisterCallback will register a callback that will fire when a transaction
+// matching a watched address enters the mempool.
+func (mp *Mempool) RegisterCallback(onRecvTx func(tx *bchutil.Tx, block *btcjson.BlockDetails)) {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+	mp.callbacks = append(mp.callbacks, onRecvTx)
+}
+
+// HaveTransaction returns whether or not the passed transaction already exists
+// in the mempool.
+func (mp *Mempool) HaveTransaction(hash *chainhash.Hash) bool {
+	mp.mtx.RLock()
+	defer mp.mtx.RUnlock()
+	return mp.downloadedTxs[*hash]
+}
+
+// AddTransaction adds a new transaction to the mempool and
+// maybe calls back if it matches any watched addresses.
+func (mp *Mempool) AddTransaction(tx *bchutil.Tx) {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+	mp.downloadedTxs[*tx.Hash()] = true
+
+	ro := defaultRescanOptions()
+	WatchAddrs(mp.watchedAddrs...)(ro)
+	if ok, err := ro.paysWatchedAddr(tx); ok && err == nil {
+		for _, cb := range mp.callbacks {
+			cb(tx, nil)
+		}
+	}
+}
+
+// Clear will remove all transactions from the mempool. This
+// should be done whenever a new block is accepted.
+func (mp *Mempool) Clear() {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+	mp.downloadedTxs = make(map[chainhash.Hash]bool)
+}
+
+// NotifyReceived stores addresses to watch
+func (mp *Mempool) NotifyReceived(addrs []bchutil.Address) {
+	mp.mtx.Lock()
+	defer mp.mtx.Unlock()
+	mp.watchedAddrs = append(mp.watchedAddrs, addrs...)
+}

--- a/neutrino.go
+++ b/neutrino.go
@@ -6,6 +6,8 @@ package neutrino
 import (
 	"errors"
 	"fmt"
+	"github.com/gcash/bchd/btcjson"
+	"github.com/gcash/bchutil/bloom"
 	"net"
 	"strconv"
 	"sync"
@@ -257,7 +259,7 @@ func (sp *ServerPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 	// service bits required to service us. If not, then we'll disconnect
 	// so we can find compatible peers.
 	peerServices := sp.Services()
-	if peerServices&wire.SFNodeCF != wire.SFNodeCF {
+	if peerServices&wire.SFNodeCF != wire.SFNodeCF || peerServices&wire.SFNodeBloom != wire.SFNodeBloom {
 
 		log.Infof("Disconnecting peer %v, cannot serve compact "+
 			"filters", sp)
@@ -290,6 +292,13 @@ func (sp *ServerPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 
 	// Add valid peer to the server.
 	sp.server.AddPeer(sp)
+
+	// If we are not in blocks only mode then send a match all bloom filter to
+	// the remote peer.
+	if !sp.server.blocksOnly {
+		filter := bloom.NewFilter(0, 0, 1, wire.BloomUpdateNone)
+		sp.QueueMessage(filter.MsgFilterLoad(), nil)
+	}
 	return nil
 }
 
@@ -302,15 +311,17 @@ func (sp *ServerPeer) OnInv(p *peer.Peer, msg *wire.MsgInv) {
 	newInv := wire.NewMsgInvSizeHint(uint(len(msg.InvList)))
 	for _, invVect := range msg.InvList {
 		if invVect.Type == wire.InvTypeTx {
-			log.Tracef("Ignoring tx %s in inv from %v -- "+
-				"SPV mode", invVect.Hash, sp)
-			if sp.ProtocolVersion() >= wire.BIP0037Version {
-				log.Infof("Peer %v is announcing "+
-					"transactions -- disconnecting", sp)
-				sp.Disconnect()
-				return
+			if sp.server.blocksOnly {
+				log.Tracef("Ignoring tx %s in inv from %v -- "+
+					"SPV mode", invVect.Hash, sp)
+				if sp.ProtocolVersion() >= wire.BIP0037Version {
+					log.Infof("Peer %v is announcing "+
+						"transactions -- disconnecting", sp)
+					sp.Disconnect()
+					return
+				}
+				continue
 			}
-			continue
 		}
 		err := newInv.AddInvVect(invVect)
 		if err != nil {
@@ -322,6 +333,17 @@ func (sp *ServerPeer) OnInv(p *peer.Peer, msg *wire.MsgInv) {
 	if len(newInv.InvList) > 0 {
 		sp.server.blockManager.QueueInv(newInv, sp)
 	}
+}
+
+// OnTx is invoked when a peer sends us a new transaction. We will will pass it
+// into the blockmanager for further processing.
+func (sp *ServerPeer) OnTx(p *peer.Peer, msg *wire.MsgTx) {
+	if sp.server.blocksOnly {
+		log.Tracef("Ignoring tx %v from %v - blocksonly enabled",
+			msg.TxHash(), sp)
+		return
+	}
+	sp.server.blockManager.QueueTx(bchutil.NewTx(msg), sp)
 }
 
 // OnHeaders is invoked when a peer receives a headers bitcoin
@@ -493,6 +515,13 @@ type Config struct {
 	// BlockCacheSize indicates the size (in bytes) of blocks the block
 	// cache will hold in memory at most.
 	BlockCacheSize uint64
+
+	// BlocksOnly sets whether or not to download unconfirmed transactions
+	// off the wire. If true the ChainService will send notifications when an
+	// unconfirmed transaction matches a watching address. The trade-off here is
+	// you're going to use a lot more bandwidth but it may be acceptable for apps
+	// which only run for brief periods of time.
+	BlocksOnly bool
 }
 
 // ChainService is instantiated with functional options
@@ -554,6 +583,10 @@ type ChainService struct {
 
 	nameResolver func(string) ([]net.IP, error)
 	dialer       func(net.Addr) (net.Conn, error)
+
+	blocksOnly bool
+
+	mempool *Mempool
 }
 
 // NewChainService returns a new chain service configured to connect to the
@@ -608,6 +641,8 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		reorgedBlockHeaders: make(map[chainhash.Hash]*wire.BlockHeader),
 		nameResolver:        nameResolver,
 		dialer:              dialer,
+		blocksOnly:          cfg.BlocksOnly,
+		mempool:             NewMempool(),
 	}
 
 	// We set the queryPeers method to point to queryChainServicePeers,
@@ -840,6 +875,18 @@ func (s *ChainService) AddBytesReceived(bytesReceived uint64) {
 func (s *ChainService) NetTotals() (uint64, uint64) {
 	return atomic.LoadUint64(&s.bytesReceived),
 		atomic.LoadUint64(&s.bytesSent)
+}
+
+// RegisterMempoolCallback registers a callback to be fired whenever a new transaction is
+// received into the mempool
+func (s *ChainService) RegisterMempoolCallback(onRecvTx func(tx *bchutil.Tx, block *btcjson.BlockDetails)) {
+	s.mempool.RegisterCallback(onRecvTx)
+}
+
+// NotifyMempoolReceived registers addresses to receive a callback on when a transaction
+// paying to them enters the mempool.
+func (s *ChainService) NotifyMempoolReceived(addrs []bchutil.Address) {
+	s.mempool.NotifyReceived(addrs)
 }
 
 // rollBackToHeight rolls back all blocks until it hits the specified height.
@@ -1211,6 +1258,7 @@ func newPeerConfig(sp *ServerPeer) *peer.Config {
 			OnAddr:      sp.OnAddr,
 			OnRead:      sp.OnRead,
 			OnWrite:     sp.OnWrite,
+			OnTx:        sp.OnTx,
 
 			// Note: The reference client currently bans peers that send alerts
 			// not signed with its key.  We could verify against their key, but
@@ -1227,6 +1275,18 @@ func newPeerConfig(sp *ServerPeer) *peer.Config {
 		ProtocolVersion:  wire.FeeFilterVersion,
 		DisableRelayTx:   true,
 	}
+}
+
+// EnableTxDownload will turn on downloading unconfirmed transactions
+// when called.
+func (s *ChainService) EnableTxDownload() {
+	s.blockManager.peerChan <- enableTxDownloadMsg{}
+}
+
+// DisableTxDownload will turn off downloading unconfirmed transactions
+// when called.
+func (s *ChainService) DisableTxDownload() {
+	s.blockManager.peerChan <- disableTxDownloadMsg{}
 }
 
 // outboundPeerConnected is invoked by the connection manager when a new

--- a/neutrino.go
+++ b/neutrino.go
@@ -52,7 +52,7 @@ var (
 
 	// RequiredServices describes the services that are required to be
 	// supported by outbound peers.
-	RequiredServices = wire.SFNodeNetwork | wire.SFNodeCF
+	RequiredServices = wire.SFNodeNetwork | wire.SFNodeCF | wire.SFNodeBloom
 
 	// BanThreshold is the maximum ban score before a peer is banned.
 	BanThreshold = uint32(100)


### PR DESCRIPTION
This commit adds unconfirmed transaction download functionality. While it's true
that this will use quite a bit of data for an SPV wallet, the way we expect
people to use an SPV wallet is to only open it for a few minutes here and there
and thus the data usage shouldn't be too great.

To get this functionality we are using match all and match none bloom filters.
This allows us to programtically turn on and off relaying on the remote peer.
It's kind of unfortunate that this way adds a dependency on NODE_BLOOM but
at least right now BCHD node support NODE_BLOOM and NODE_CF by default so
this shouldn't be that big of a deal.

It will also allow for a future 'trusted peer' mode where we use the bloom
filter the normal way to reduce bandwidth since we aren't concerned about
privacy if we're connected to a trusted peer.