### PR TITLE
Refactor switch back to using outpoints

### DIFF
--- a/bamboozle_unit_test.go
+++ b/bamboozle_unit_test.go
@@ -123,7 +123,7 @@ var (
 			},
 		},
 	}
-	correctFilter, _ = builder.BuildBasicFilter(block, nil)
+	correctFilter, _ = builder.BuildBasicFilter(block)
 
 	fakeFilter1, _ = gcs.FromBytes(2, builder.DefaultP, builder.DefaultM, []byte{
 		0x30, 0x43, 0x02, 0x1f, 0x4d, 0x23, 0x81, 0xdc,
@@ -167,7 +167,7 @@ var (
 				decodeHashNoError("fedcba09f7654321001234567890abcdef"),
 			},
 		}
-		filter, _ := builder.BuildBasicFilter(block, nil)
+		filter, _ := builder.BuildBasicFilter(block)
 		filterHash, _ := builder.GetFilterHash(filter)
 		cfh.FilterHashes = append(cfh.FilterHashes, &filterHash)
 		return cfh

--- a/blockmanager_test.go
+++ b/blockmanager_test.go
@@ -112,9 +112,7 @@ func generateHeaders(genesisBlockHeader *wire.BlockHeader,
 	// The filter hashes (not the filter headers!) will be sent as
 	// part of the CFHeaders response, so we also keep track of
 	// them.
-	genesisFilter, err := builder.BuildBasicFilter(
-		chaincfg.SimNetParams.GenesisBlock, nil,
-	)
+	genesisFilter, err := builder.BuildBasicFilter(chaincfg.SimNetParams.GenesisBlock)
 	if err != nil {
 		return nil, fmt.Errorf("unable to build genesis filter: %v",
 			err)
@@ -421,8 +419,7 @@ func TestBlockManagerInitialInterval(t *testing.T) {
 // TestBlockManagerInvalidInterval tests that the block manager is able to
 // determine it is receiving corrupt checkpoints and filter headers.
 func TestBlockManagerInvalidInterval(t *testing.T) {
-	t.Parallel()
-
+	//t.Parallel()
 	type testCase struct {
 		// wrongGenesis indicates whether we should start deriving the
 		// filters from a wrong genesis.
@@ -486,7 +483,6 @@ func TestBlockManagerInvalidInterval(t *testing.T) {
 			firstInvalid:    1,
 		},
 	}
-
 	for _, test := range testCases {
 		bm, hdrStore, cfStore, cleanUp, err := setupBlockManager()
 		if err != nil {

--- a/filterdb/db.go
+++ b/filterdb/db.go
@@ -91,7 +91,7 @@ func New(db walletdb.DB, params chaincfg.Params) (*FilterStore, error) {
 
 		// With the bucket created, we'll now construct the initial
 		// basic genesis filter and store it within the database.
-		basicFilter, err := builder.BuildBasicFilter(genesisBlock, nil)
+		basicFilter, err := builder.BuildBasicFilter(genesisBlock)
 		if err != nil {
 			return err
 		}

--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -669,9 +669,7 @@ func NewFilterHeaderStore(filePath string, db walletdb.DB,
 		var genesisFilterHash chainhash.Hash
 		switch filterType {
 		case RegularFilter:
-			basicFilter, err := builder.BuildBasicFilter(
-				netParams.GenesisBlock, nil,
-			)
+			basicFilter, err := builder.BuildBasicFilter(netParams.GenesisBlock)
 			if err != nil {
 				return nil, err
 			}

--- a/query.go
+++ b/query.go
@@ -711,7 +711,7 @@ checkResponses:
 func (s *ChainService) getFilterFromCache(blockHash *chainhash.Hash,
 	filterType filterdb.FilterType) (*gcs.Filter, error) {
 
-	cacheKey := cache.FilterCacheKey{*blockHash, filterType}
+	cacheKey := cache.FilterCacheKey{BlockHash: *blockHash, FilterType: filterType}
 
 	filterValue, err := s.FilterCache.Get(cacheKey)
 	if err != nil {
@@ -725,7 +725,7 @@ func (s *ChainService) getFilterFromCache(blockHash *chainhash.Hash,
 func (s *ChainService) putFilterToCache(blockHash *chainhash.Hash,
 	filterType filterdb.FilterType, filter *gcs.Filter) error {
 
-	cacheKey := cache.FilterCacheKey{*blockHash, filterType}
+	cacheKey := cache.FilterCacheKey{BlockHash: *blockHash, FilterType: filterType}
 	return s.FilterCache.Put(cacheKey, &cache.CacheableFilter{Filter: filter})
 }
 

--- a/rescan.go
+++ b/rescan.go
@@ -230,7 +230,12 @@ func rescan(chain ChainSource, options ...RescanOption) error {
 		ro.watchList = append(ro.watchList, script)
 	}
 	for _, input := range ro.watchInputs {
+		var buf bytes.Buffer
+		if err := input.OutPoint.Serialize(&buf); err != nil {
+			return err
+		}
 		ro.watchList = append(ro.watchList, input.PkScript)
+		ro.watchList = append(ro.watchList, buf.Bytes())
 	}
 
 	// Check that we have either an end block or a quit channel.
@@ -1013,7 +1018,12 @@ func (ro *rescanOptions) updateFilter(chain ChainSource, update *updateOptions,
 		ro.watchList = append(ro.watchList, script)
 	}
 	for _, input := range update.inputs {
+		var buf bytes.Buffer
+		if err := input.OutPoint.Serialize(&buf); err != nil {
+			return false, err
+		}
 		ro.watchList = append(ro.watchList, input.PkScript)
+		ro.watchList = append(ro.watchList, buf.Bytes())
 	}
 	for _, txid := range update.txIDs {
 		ro.watchList = append(ro.watchList, txid[:])
@@ -1117,7 +1127,12 @@ txOutLoop:
 				PkScript: pkScript,
 				OutPoint: outPoint,
 			})
+			var buf bytes.Buffer
+			if err := outPoint.Serialize(&buf); err != nil {
+				return false, err
+			}
 			ro.watchList = append(ro.watchList, pkScript)
+			ro.watchList = append(ro.watchList, buf.Bytes())
 
 			continue txOutLoop
 		}

--- a/sync_test.go
+++ b/sync_test.go
@@ -522,6 +522,7 @@ func testStartRescan(harness *neutrinoHarness, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sign transaction: %s", err)
 	}
+
 	banPeer(harness.svc, harness.h2)
 	err = harness.svc.SendTransaction(authTx1.Tx)
 	if err != nil && !strings.Contains(err.Error(), "already have") {
@@ -564,6 +565,7 @@ func testStartRescan(harness *neutrinoHarness, t *testing.T) {
 	if err != nil {
 		t.Fatalf("Couldn't sign transaction: %s", err)
 	}
+
 	banPeer(harness.svc, harness.h2)
 	err = harness.svc.SendTransaction(authTx2.Tx)
 	if err != nil && !strings.Contains(err.Error(), "already have") {
@@ -910,20 +912,8 @@ func testRandomBlocks(harness *neutrinoHarness, t *testing.T) {
 				return
 			}
 
-			inputScripts, err := fetchPrevInputScripts(
-				haveBlock.MsgBlock(),
-				harness.h1,
-			)
-			if err != nil {
-				errChan <- fmt.Errorf("unable to create prev "+
-					"input scripts: %v", err)
-				return
-			}
-
 			// Calculate basic filter from block.
-			calcFilter, err := builder.BuildBasicFilter(
-				haveBlock.MsgBlock(), inputScripts,
-			)
+			calcFilter, err := builder.BuildBasicFilter(haveBlock.MsgBlock())
 			if err != nil {
 				errChan <- fmt.Errorf("Couldn't build basic "+
 					"filter for block %d (%s): %s", height,
@@ -1352,7 +1342,7 @@ func startRescan(t *testing.T, svc *neutrino.ChainService, addr bchutil.Address,
 	startBlock *waddrmgr.BlockStamp, quit <-chan struct{}) (
 	*neutrino.Rescan, <-chan error) {
 	rescan := neutrino.NewRescan(
-		&neutrino.RescanChainSource{svc},
+		&neutrino.RescanChainSource{ChainService: svc},
 		neutrino.QuitChan(quit),
 		neutrino.WatchAddrs(addr),
 		neutrino.StartBlock(startBlock),


### PR DESCRIPTION
This is a significant refactor to switch the codebase back to using outpoints
in the filter instead of input-scriptpubkeys. This makes it so we can detect
misbehaving peers and ban them. It requires updating all places in the code
which interact with the filter and check for matches.