### PR TITLE
Add PersistToDisk property to ChainService

### DIFF
--- a/headerfs/store.go
+++ b/headerfs/store.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
+	"time"
 
 	"github.com/gcash/bchd/blockchain"
 	"github.com/gcash/bchd/chaincfg"
@@ -15,8 +17,6 @@ import (
 	"github.com/gcash/bchutil/gcs/builder"
 	"github.com/gcash/bchwallet/waddrmgr"
 	"github.com/gcash/bchwallet/walletdb"
-	"sort"
-	"time"
 )
 
 // BlockHeaderStore is an interface that provides an abstraction for a generic
@@ -334,11 +334,11 @@ func (h *blockHeaderStore) RollbackLastBlock() (*waddrmgr.BlockStamp, error) {
 	// With this height obtained, we'll use it to read the latest header
 	// from disk, so we can populate our return value which requires the
 	// prev header hash.
-	bestHeader, err := h.readHeader(chainTipHeight)
+	prevHeader, err := h.readHeader(chainTipHeight - 1)
 	if err != nil {
 		return nil, err
 	}
-	prevHeaderHash := bestHeader.PrevBlock
+	prevHeaderHash := prevHeader.BlockHash()
 
 	// Now that we have the information we need to return from this
 	// function, we can now truncate the header file, and then use the hash
@@ -351,8 +351,9 @@ func (h *blockHeaderStore) RollbackLastBlock() (*waddrmgr.BlockStamp, error) {
 	}
 
 	return &waddrmgr.BlockStamp{
-		Height: int32(chainTipHeight) - 1,
-		Hash:   prevHeaderHash,
+		Height:    int32(chainTipHeight) - 1,
+		Hash:      prevHeaderHash,
+		Timestamp: prevHeader.Timestamp,
 	}, nil
 }
 

--- a/neutrino.go
+++ b/neutrino.go
@@ -540,6 +540,12 @@ type Config struct {
 	// Proxy is an address to use to connect remote peers using the socks5 proxy.
 	Proxy string
 
+	// PersistToDisk indicates whether the filter should also be written
+	// to disk in addition to the memory cache. For "normal" wallets, they'll
+	// almost never need to re-match a filter once it's been fetched unless
+	// they're doing something like a key import.
+	PersistToDisk bool
+
 	// AssertFilterHeader is an optional field that allows the creator of
 	// the ChainService to ensure that if any chain data exists, it's
 	// compliant with the expected filter header state. If neutrino starts
@@ -570,6 +576,7 @@ type ChainService struct {
 	FilterDB         filterdb.FilterDatabase
 	BlockHeaders     headerfs.BlockHeaderStore
 	RegFilterHeaders *headerfs.FilterHeaderStore
+	persistToDisk    bool
 
 	FilterCache *lru.Cache
 	BlockCache  *lru.Cache
@@ -678,6 +685,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		blocksOnly:        cfg.BlocksOnly,
 		mempool:           NewMempool(),
 		proxy:             cfg.Proxy,
+		persistToDisk:     cfg.PersistToDisk,
 		broadcastTimeout:  cfg.BroadcastTimeout,
 	}
 

--- a/neutrino.go
+++ b/neutrino.go
@@ -1377,6 +1377,12 @@ func (s *ChainService) handleAddPeerMsg(state *peerState, sp *ServerPeer) bool {
 		s.firstPeerConnect = nil
 	}
 
+	// Update the address' last seen time if the peer has acknowledged our
+	// version and has sent us its version as well.
+	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
+		s.addrManager.Connected(sp.NA())
+	}
+
 	return true
 }
 
@@ -1410,12 +1416,6 @@ func (s *ChainService) handleDonePeerMsg(state *peerState, sp *ServerPeer) {
 		} else {
 			s.connManager.Disconnect(sp.connReq.ID())
 		}
-	}
-
-	// Update the address' last seen time if the peer has acknowledged
-	// our version and has sent us its version as well.
-	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
-		s.addrManager.Connected(sp.NA())
 	}
 
 	// If we get here it means that either we didn't know about the peer

--- a/neutrino.go
+++ b/neutrino.go
@@ -12,12 +12,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gcash/bchd/btcjson"
-	"github.com/gcash/bchd/txscript"
-	"github.com/gcash/bchutil/gcs"
-	"github.com/gcash/bchutil/gcs/builder"
-	"github.com/gcash/neutrino/banman"
-
 	"github.com/gcash/bchd/addrmgr"
 	"github.com/gcash/bchd/blockchain"
 	"github.com/gcash/bchd/btcjson"
@@ -93,6 +87,13 @@ var (
 	// keep in memory if no size is specified in the neutrino.Config.
 	DefaultBlockCacheSize uint64 = 4096 * 10 * 1000 // 40 MB
 )
+
+// isDevNetwork indicates if the chain is a private development network, namely
+// simnet or regtest/regnet.
+func isDevNetwork(net wire.BitcoinNet) bool {
+	return net == chaincfg.SimNetParams.Net ||
+		net == chaincfg.RegressionNetParams.Net
+}
 
 // updatePeerHeightsMsg is a message sent from the blockmanager to the server
 // after a new block has been accepted. The purpose of the message is to update
@@ -377,11 +378,11 @@ func (sp *ServerPeer) OnReject(_ *peer.Peer, msg *wire.MsgReject) {
 // OnAddr is invoked when a peer receives an addr bitcoin message and is
 // used to notify the server about advertised addresses.
 func (sp *ServerPeer) OnAddr(_ *peer.Peer, msg *wire.MsgAddr) {
-	// Ignore addresses when running on the simulation test network.  This
+	// Ignore addresses when running on a private development network.  This
 	// helps prevent the network from becoming another public test network
 	// since it will not be able to learn about other peers that have not
 	// specifically been provided.
-	if sp.server.chainParams.Net == chaincfg.SimNetParams.Net {
+	if isDevNetwork(sp.server.chainParams.Net) {
 		return
 	}
 
@@ -735,12 +736,12 @@ func NewChainService(cfg Config) (*ChainService, error) {
 	s.blockSubscriptionMgr = blockntfns.NewSubscriptionManager(s.blockManager)
 
 	// Only setup a function to return new addresses to connect to when not
-	// running in connect-only mode.  The simulation network is always in
-	// connect-only mode since it is only intended to connect to specified
-	// peers and actively avoid advertising and connecting to discovered
-	// peers in order to prevent it from becoming a public test network.
+	// running in connect-only mode.  Private development networks are always in
+	// connect-only mode since it is only intended to connect to specified peers
+	// and actively avoid advertising and connecting to discovered peers in
+	// order to prevent it from becoming a public test network.
 	var newAddressFunc func() (net.Addr, error)
-	if s.chainParams.Net != chaincfg.SimNetParams.Net {
+	if !isDevNetwork(s.chainParams.Net) {
 		newAddressFunc = func() (net.Addr, error) {
 
 			// Gather our set of currently connected peers to avoid
@@ -1351,10 +1352,10 @@ func (s *ChainService) handleAddPeerMsg(state *peerState, sp *ServerPeer) bool {
 
 	// Update the address manager and request known addresses from the
 	// remote peer for outbound connections. This is skipped when running on
-	// the simulation test network since it is only intended to connect to
+	// a development network since it is only intended to connect to
 	// specified peers and actively avoids advertising and connecting to
 	// discovered peers.
-	if s.chainParams.Net != chaincfg.SimNetParams.Net {
+	if !isDevNetwork(s.chainParams.Net) {
 		// Request known addresses if the server address manager needs
 		// more and the peer has a protocol version new enough to
 		// include a timestamp with addresses.

--- a/neutrino.go
+++ b/neutrino.go
@@ -6,11 +6,6 @@ package neutrino
 import (
 	"errors"
 	"fmt"
-	"github.com/gcash/bchd/btcjson"
-	"github.com/gcash/bchd/txscript"
-	"github.com/gcash/bchutil/gcs"
-	"github.com/gcash/bchutil/gcs/builder"
-	"github.com/gcash/neutrino/banman"
 	"net"
 	"strconv"
 	"sync"
@@ -19,14 +14,19 @@ import (
 
 	"github.com/gcash/bchd/addrmgr"
 	"github.com/gcash/bchd/blockchain"
+	"github.com/gcash/bchd/btcjson"
 	"github.com/gcash/bchd/chaincfg"
 	"github.com/gcash/bchd/chaincfg/chainhash"
 	"github.com/gcash/bchd/connmgr"
 	"github.com/gcash/bchd/peer"
+	"github.com/gcash/bchd/txscript"
 	"github.com/gcash/bchd/wire"
 	"github.com/gcash/bchutil"
+	"github.com/gcash/bchutil/gcs"
+	"github.com/gcash/bchutil/gcs/builder"
 	"github.com/gcash/bchwallet/waddrmgr"
 	"github.com/gcash/bchwallet/walletdb"
+	"github.com/gcash/neutrino/banman"
 	"github.com/gcash/neutrino/blockntfns"
 	"github.com/gcash/neutrino/cache/lru"
 	"github.com/gcash/neutrino/filterdb"
@@ -919,8 +919,9 @@ func (s *ChainService) BestBlock() (*waddrmgr.BlockStamp, error) {
 	}
 
 	return &waddrmgr.BlockStamp{
-		Height: int32(bestHeight),
-		Hash:   bestHeader.BlockHash(),
+		Height:    int32(bestHeight),
+		Hash:      bestHeader.BlockHash(),
+		Timestamp: bestHeader.Timestamp,
 	}, nil
 }
 
@@ -1115,8 +1116,9 @@ func (s *ChainService) rollBackToHeight(height uint32) (*waddrmgr.BlockStamp, er
 		return nil, err
 	}
 	bs := &waddrmgr.BlockStamp{
-		Height: int32(headerHeight),
-		Hash:   header.BlockHash(),
+		Height:    int32(headerHeight),
+		Hash:      header.BlockHash(),
+		Timestamp: header.Timestamp,
 	}
 
 	_, regHeight, err := s.RegFilterHeaders.ChainTip()

--- a/neutrino.go
+++ b/neutrino.go
@@ -12,6 +12,12 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/gcash/bchd/btcjson"
+	"github.com/gcash/bchd/txscript"
+	"github.com/gcash/bchutil/gcs"
+	"github.com/gcash/bchutil/gcs/builder"
+	"github.com/gcash/neutrino/banman"
+
 	"github.com/gcash/bchd/addrmgr"
 	"github.com/gcash/bchd/blockchain"
 	"github.com/gcash/bchd/btcjson"
@@ -248,21 +254,10 @@ func (sp *ServerPeer) addBanScore(persistent, transient uint32, reason string) {
 	}
 }
 
-// pushSendHeadersMsg sends a sendheaders message to the connected peer.
-func (sp *ServerPeer) pushSendHeadersMsg() error {
-	if sp.VersionKnown() {
-		if sp.ProtocolVersion() > wire.SendHeadersVersion {
-			sp.QueueMessage(wire.NewMsgSendHeaders(), nil)
-		}
-	}
-	return nil
-}
-
 // OnVerAck is invoked when a peer receives a verack bitcoin message and is used
-// to send the "sendheaders" command to peers that are of a sufficienty new
-// protocol version.
+// to kick start communication with them.
 func (sp *ServerPeer) OnVerAck(_ *peer.Peer, msg *wire.MsgVerAck) {
-	sp.pushSendHeadersMsg()
+	sp.server.AddPeer(sp)
 }
 
 // OnVersion is invoked when a peer receives a version bitcoin message
@@ -292,47 +287,15 @@ func (sp *ServerPeer) OnVersion(_ *peer.Peer, msg *wire.MsgVersion) *wire.MsgRej
 		return nil
 	}
 
-	// Signal the block manager this peer is a new sync candidate.
-	sp.server.blockManager.NewPeer(sp)
-
-	// Update the address manager and request known addresses from the
-	// remote peer for outbound connections.  This is skipped when running
-	// on the simulation test network since it is only intended to connect
-	// to specified peers and actively avoids advertising and connecting to
-	// discovered peers.
-	if sp.server.chainParams.Net != chaincfg.SimNetParams.Net {
-		addrManager := sp.server.addrManager
-
-		// Request known addresses if the server address manager needs
-		// more and the peer has a protocol version new enough to
-		// include a timestamp with addresses.
-		hasTimestamp := sp.ProtocolVersion() >=
-			wire.NetAddressTimeVersion
-		if addrManager.NeedMoreAddresses() && hasTimestamp {
-			sp.QueueMessage(wire.NewMsgGetAddr(), nil)
-		}
-
-		// Add the address to the addr manager anew, and also mark it
-		// as a good address.
-		sp.server.addrManager.AddAddresses(
-			[]*wire.NetAddress{sp.NA()}, sp.NA(),
-		)
-		addrManager.Good(sp.NA())
-
-		// Update the address manager with the advertised services for
-		// outbound connections in case they have changed. This is not
-		// done for inbound connections to help prevent malicious
-		// behavior and is skipped when running on the simulation test
-		// network since it is only intended to connect to specified
-		// peers and actively avoids advertising and connecting to
-		// discovered peers.
-		if !sp.Inbound() {
-			sp.server.addrManager.SetServices(sp.NA(), msg.Services)
-		}
+	// Update the address manager with the advertised services for outbound
+	// connections in case they have changed. This is not done for inbound
+	// connections to help prevent malicious behavior and is skipped when
+	// running on the simulation test network since it is only intended to
+	// connect to specified peers and actively avoids advertising and
+	// connecting to discovered peers.
+	if !sp.Inbound() {
+		sp.server.addrManager.SetServices(sp.NA(), msg.Services)
 	}
-
-	// Add valid peer to the server.
-	sp.server.AddPeer(sp)
 
 	return nil
 }
@@ -1333,7 +1296,7 @@ func (s *ChainService) handleUpdatePeerHeights(state *peerState, umsg updatePeer
 // handleAddPeerMsg deals with adding new peers.  It is invoked from the
 // peerHandler goroutine.
 func (s *ChainService) handleAddPeerMsg(state *peerState, sp *ServerPeer) bool {
-	if sp == nil {
+	if sp == nil || !sp.Connected() {
 		return false
 	}
 
@@ -1381,6 +1344,29 @@ func (s *ChainService) handleAddPeerMsg(state *peerState, sp *ServerPeer) bool {
 	// version and has sent us its version as well.
 	if sp.VerAckReceived() && sp.VersionKnown() && sp.NA() != nil {
 		s.addrManager.Connected(sp.NA())
+	}
+
+	// Signal the block manager this peer is a new sync candidate.
+	s.blockManager.NewPeer(sp)
+
+	// Update the address manager and request known addresses from the
+	// remote peer for outbound connections. This is skipped when running on
+	// the simulation test network since it is only intended to connect to
+	// specified peers and actively avoids advertising and connecting to
+	// discovered peers.
+	if s.chainParams.Net != chaincfg.SimNetParams.Net {
+		// Request known addresses if the server address manager needs
+		// more and the peer has a protocol version new enough to
+		// include a timestamp with addresses.
+		hasTimestamp := sp.ProtocolVersion() >= wire.NetAddressTimeVersion
+		if s.addrManager.NeedMoreAddresses() && hasTimestamp {
+			sp.QueueMessage(wire.NewMsgGetAddr(), nil)
+		}
+
+		// Add the address to the addr manager anew, and also mark it as
+		// a good address.
+		s.addrManager.AddAddresses([]*wire.NetAddress{sp.NA()}, sp.NA())
+		s.addrManager.Good(sp.NA())
 	}
 
 	return true
@@ -1462,8 +1448,8 @@ func (s *ChainService) SendTransaction(tx *wire.MsgTx) error {
 func newPeerConfig(sp *ServerPeer) *peer.Config {
 	return &peer.Config{
 		Listeners: peer.MessageListeners{
-			OnVersion: sp.OnVersion,
-			//OnVerAck:    sp.OnVerAck, // Don't use sendheaders yet
+			OnVersion:   sp.OnVersion,
+			OnVerAck:    sp.OnVerAck,
 			OnInv:       sp.OnInv,
 			OnHeaders:   sp.OnHeaders,
 			OnReject:    sp.OnReject,

--- a/neutrino.go
+++ b/neutrino.go
@@ -582,6 +582,16 @@ type Config struct {
 	// up and this filter header state has diverged, then it'll remove the
 	// current on disk filter headers to sync them anew.
 	AssertFilterHeader *headerfs.FilterHeader
+
+	// BroadcastTimeout is the amount of time we'll wait before giving up on
+	// a transaction broadcast attempt. Broadcasting transactions consists
+	// of three steps:
+	//
+	// 1. Neutrino sends an inv for the transaction.
+	// 2. The recipient node determines if the inv is known, and if it's
+	//    not, replies with a getdata message.
+	// 3. Neutrino sends the raw transaction.
+	BroadcastTimeout time.Duration
 }
 
 // ChainService is instantiated with functional options
@@ -642,12 +652,19 @@ type ChainService struct {
 	mempool *Mempool
 
 	proxy string
+
+	broadcastTimeout time.Duration
 }
 
 // NewChainService returns a new chain service configured to connect to the
 // bitcoin network type specified by chainParams.  Use start to begin syncing
 // with peers.
 func NewChainService(cfg Config) (*ChainService, error) {
+	// Use the default broadcast timeout if one isn't provided.
+	if cfg.BroadcastTimeout == 0 {
+		cfg.BroadcastTimeout = pushtx.DefaultBroadcastTimeout
+	}
+
 	// First, we'll sort out the methods that we'll use to established
 	// outbound TCP connections, as well as perform any DNS queries.
 	//
@@ -697,6 +714,7 @@ func NewChainService(cfg Config) (*ChainService, error) {
 		blocksOnly:        cfg.BlocksOnly,
 		mempool:           NewMempool(),
 		proxy:             cfg.Proxy,
+		broadcastTimeout:  cfg.BroadcastTimeout,
 	}
 
 	// We set the queryPeers method to point to queryChainServicePeers,

--- a/pushtx/broadcaster.go
+++ b/pushtx/broadcaster.go
@@ -20,6 +20,10 @@ var (
 )
 
 const (
+	// DefaultBroadcastTimeout is the default timeout used when broadcasting
+	// transactions to network peers.
+	DefaultBroadcastTimeout = 5 * time.Second
+
 	// DefaultRebroadcastInterval is the default period that we'll wait
 	// between blocks to attempt another rebroadcast.
 	DefaultRebroadcastInterval = time.Minute

--- a/query.go
+++ b/query.go
@@ -106,12 +106,6 @@ type queryOptions struct {
 	// it's run in a goroutine.
 	doneChan chan<- struct{}
 
-	// persistToDisk indicates whether the filter should also be written
-	// to disk in addition to the memory cache. For "normal" wallets, they'll
-	// almost never need to re-match a filter once it's been fetched unless
-	// they're doing something like a key import.
-	persistToDisk bool
-
 	// invalidTxThreshold is the threshold for the fraction of peers
 	// that need to respond to a TX with a code of pushtx.Invalid to count
 	// it as invalid, even if not all peers respond. This option is only
@@ -228,14 +222,6 @@ func Encoding(encoding wire.MessageEncoding) QueryOption {
 func DoneChan(doneChan chan<- struct{}) QueryOption {
 	return func(qo *queryOptions) {
 		qo.doneChan = doneChan
-	}
-}
-
-// PersistToDisk allows the caller to tell that the filter should be kept
-// on disk once it's found.
-func PersistToDisk() QueryOption {
-	return func(qo *queryOptions) {
-		qo.persistToDisk = true
 	}
 }
 
@@ -1161,7 +1147,7 @@ func (s *ChainService) handleCFiltersResponse(q *cfiltersQuery,
 
 	qo := defaultQueryOptions()
 	qo.applyQueryOptions(q.options...)
-	if qo.persistToDisk {
+	if s.persistToDisk {
 		err = s.FilterDB.PutFilter(
 			&response.BlockHash, gotFilter, dbFilterType,
 		)

--- a/query.go
+++ b/query.go
@@ -33,6 +33,17 @@ var (
 	// to a peer that previously failed because of a timeout.
 	QueryPeerCooldown = time.Second * 5
 
+	// QueryRejectTimeout is the time we'll wait after sending a response to
+	// an INV query for a potential reject answer. If we don't get a reject
+	// before this delay, we assume the TX was accepted.
+	QueryRejectTimeout = time.Second
+
+	// QueryInvalidTxThreshold is the threshold for the fraction of peers
+	// that need to respond to a TX with a code of pushtx.Invalid to count
+	// it as invalid, even if not all peers respond. This currently
+	// corresponds to 60% of peers that need to reject.
+	QueryInvalidTxThreshold float32 = 0.6
+
 	// QueryNumRetries specifies how many times to retry sending a query to
 	// each peer before we've concluded we aren't going to get a valid
 	// response. This allows to make up for missed messages in some
@@ -81,6 +92,12 @@ type queryOptions struct {
 	// on a query in case we don't have any peers.
 	peerConnectTimeout time.Duration
 
+	// rejectTimeout is the time we'll wait after sending a response to an
+	// INV query for a potential reject answer. If we don't get a reject
+	// before this delay, we assume the TX was accepted. This option is only
+	// used when publishing a transaction.
+	rejectTimeout time.Duration
+
 	// encoding lets the query know which encoding to use when queueing
 	// messages to a peer.
 	encoding wire.MessageEncoding
@@ -94,6 +111,12 @@ type queryOptions struct {
 	// almost never need to re-match a filter once it's been fetched unless
 	// they're doing something like a key import.
 	persistToDisk bool
+
+	// invalidTxThreshold is the threshold for the fraction of peers
+	// that need to respond to a TX with a code of pushtx.Invalid to count
+	// it as invalid, even if not all peers respond. This option is only
+	// used when publishing a transaction.
+	invalidTxThreshold float32
 
 	// optimisticBatch indicates whether we expect more calls to follow,
 	// and that we should attempt to batch more items with the query such
@@ -131,7 +154,9 @@ func defaultQueryOptions() *queryOptions {
 		timeout:            QueryTimeout,
 		numRetries:         uint8(QueryNumRetries),
 		peerConnectTimeout: QueryPeerConnectTimeout,
+		rejectTimeout:      QueryRejectTimeout,
 		encoding:           QueryEncoding,
+		invalidTxThreshold: QueryInvalidTxThreshold,
 		optimisticBatch:    noBatch,
 	}
 }
@@ -159,12 +184,34 @@ func NumRetries(numRetries uint8) QueryOption {
 	}
 }
 
+// InvalidTxThreshold is the threshold for the fraction of peers that need to
+// respond to a TX with a code of pushtx.Invalid to count it as invalid, even
+// if not all peers respond.
+//
+// NOTE: This option is currently only used when publishing a transaction.
+func InvalidTxThreshold(invalidTxThreshold float32) QueryOption {
+	return func(qo *queryOptions) {
+		qo.invalidTxThreshold = invalidTxThreshold
+	}
+}
+
 // PeerConnectTimeout is a query option that lets the query know how long to
 // wait for the underlying chain service to connect to a peer before giving up
 // on a query in case we don't have any peers.
 func PeerConnectTimeout(timeout time.Duration) QueryOption {
 	return func(qo *queryOptions) {
 		qo.peerConnectTimeout = timeout
+	}
+}
+
+// RejectTimeout is the time we'll wait after sending a response to an INV
+// query for a potential reject answer. If we don't get a reject before this
+// delay, we assume the TX was accepted.
+//
+// NOTE: This option is currently only used when publishing a transaction.
+func RejectTimeout(rejectTimeout time.Duration) QueryOption {
+	return func(qo *queryOptions) {
+		qo.rejectTimeout = rejectTimeout
 	}
 }
 
@@ -1396,17 +1443,32 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 	inv := wire.NewMsgInv()
 	inv.AddInvVect(wire.NewInvVect(invType, &txHash))
 
-	// We'll gather all of the peers who replied to our query, along with
+	// We'll gather all the peers who replied to our query, along with
 	// the ones who rejected it and their reason for rejecting it. We'll use
 	// this to determine whether our transaction was actually rejected.
-	numReplied := 0
-	rejections := make(map[pushtx.BroadcastError]int)
+	replies := make(map[int32]struct{})
+	rejections := make(map[int32]*pushtx.BroadcastError)
+	rejectCodes := make(map[pushtx.BroadcastErrorCode]int)
+
+	// closers is a map that tracks the delayed closers we need to make sure
+	// the peer quit channel is closed after a timeout.
+	closers := make(map[int32]*delayedCloser)
 
 	// Send the peer query and listen for getdata.
 	s.queryAllPeers(
 		inv,
 		func(sp *ServerPeer, resp wire.Message, quit chan<- struct{},
 			peerQuit chan<- struct{}) {
+
+			// The "closer" can be used to either close the peer
+			// quit channel after a certain timeout or immediately.
+			closer, ok := closers[sp.ID()]
+			if !ok {
+				closer = newDelayedCloser(
+					peerQuit, qo.rejectTimeout,
+				)
+				closers[sp.ID()] = closer
+			}
 
 			switch response := resp.(type) {
 			// A peer has replied with a GetData message, so we'll
@@ -1418,7 +1480,24 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 							tx, nil, qo.encoding,
 						)
 
-						numReplied++
+						// Peers might send the INV
+						// request multiple times, we
+						// need to de-duplicate them
+						// using a map.
+						replies[sp.ID()] = struct{}{}
+
+						// Okay, so the peer responded
+						// with an INV message, and we
+						// sent out the TX. If we never
+						// hear anything back from the
+						// peer it means they accepted
+						// the tx. If we get a reject,
+						// things are clear as well. But
+						// what if they are just slow to
+						// respond? We'll give them
+						// another bit of time to
+						// respond.
+						closer.closeEventually(s.quit)
 					}
 				}
 
@@ -1436,7 +1515,18 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 				broadcastErr := pushtx.ParseBroadcastError(
 					response, sp.Addr(),
 				)
-				rejections[*broadcastErr]++
+				rejections[sp.ID()] = broadcastErr
+				rejectCodes[broadcastErr.Code]++
+
+				log.Debugf("Transaction %v rejected by peer "+
+					"%v: code = %v, reason = %q", txHash,
+					sp.Addr(), broadcastErr.Code,
+					broadcastErr.Reason)
+
+				// A reject message is final, so we can close
+				// the peer quit channel now, we don't expect
+				// any further messages.
+				closer.closeNow()
 			}
 		},
 		// Default to 500ms timeout. Default for queryAllPeers is a
@@ -1455,39 +1545,116 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 	// If none of our peers replied to our query, we'll avoid returning an
 	// error as the reliable broadcaster will take care of broadcasting this
 	// transaction upon every block connected/disconnected.
-	if numReplied == 0 {
+	if len(replies) == 0 {
 		log.Debugf("No peers replied to inv message for transaction %v",
 			tx.TxHash())
 		return nil
 	}
 
-	// If all of our peers who replied to our query also rejected our
-	// transaction, we'll deem that there was actually something wrong with
-	// it so we'll return the most rejected error between all of our peers.
-	//
-	// TODO(wilmer): This might be too naive, some rejections are more
-	// critical than others.
-	//
-	// TODO(wilmer): This does not cover the case where a peer also rejected
-	// our transaction but didn't send the response within our given timeout
-	// and certain other cases. Due to this, we should probably decide on a
-	// threshold of rejections instead.
-	if numReplied == len(rejections) {
-		log.Warnf("All peers rejected transaction %v checking errors",
-			tx.TxHash())
-
-		mostRejectedCount := 0
-		var mostRejectedErr pushtx.BroadcastError
-
-		for broadcastErr, count := range rejections {
-			if count > mostRejectedCount {
-				mostRejectedCount = count
-				mostRejectedErr = broadcastErr
+	// firstRejectWithCode returns the first reject error that we have for
+	// a certain error code.
+	firstRejectWithCode := func(code pushtx.BroadcastErrorCode) error {
+		for _, broadcastErr := range rejections {
+			if broadcastErr.Code == code {
+				return broadcastErr
 			}
 		}
 
-		return &mostRejectedErr
+		// We can't really get here unless something is totally wrong in
+		// the above error mapping code.
+		return fmt.Errorf("invalid error mapping")
+	}
+
+	// If all of our peers who replied to our query also rejected our
+	// transaction, we'll deem that there was actually something wrong with
+	// it, so we'll return the most rejected error between all of our peers.
+	log.Debugf("Got replies from %d peers and %d rejections", len(replies),
+		len(rejections))
+	if len(replies) == len(rejections) {
+		log.Warnf("All peers rejected transaction %v checking errors",
+			tx.TxHash())
+
+		// First, find the reject code that was returned most often.
+		var (
+			mostRejectedCount = 0
+			mostRejectedCode  pushtx.BroadcastErrorCode
+		)
+		for code, count := range rejectCodes {
+			if count > mostRejectedCount {
+				mostRejectedCount = count
+				mostRejectedCode = code
+			}
+		}
+
+		// Then return the first error we have for that code (it doesn't
+		// really matter which one, as long as our error code parsing is
+		// correct).
+		return firstRejectWithCode(mostRejectedCode)
+	}
+
+	// We did get some rejections, but not from all peers. Perhaps that's
+	// due to some peers responding too slowly. Or it could also be a
+	// malicious peer trying to block us from publishing a TX. That's why
+	// we want to check if more than 60% of the peers (by default) that
+	// replied in time also sent a reject, we can be pretty certain that
+	// this TX is probably invalid.
+	if len(rejections) > 0 {
+		numInvalid := float32(rejectCodes[pushtx.Invalid])
+		numPeersResponded := float32(len(replies))
+
+		log.Debugf("Of %d peers that replied, %d think the TX is "+
+			"invalid", numPeersResponded, numInvalid)
+
+		// 60% or more (by default) of the peers declared this TX as
+		// invalid.
+		if numInvalid/numPeersResponded >= qo.invalidTxThreshold {
+			log.Warnf("Threshold of %d reached (%d out of %d "+
+				"peers), declaring TX %v as invalid",
+				qo.invalidTxThreshold, numInvalid,
+				numPeersResponded, txHash)
+
+			return firstRejectWithCode(pushtx.Invalid)
+		}
 	}
 
 	return nil
+}
+
+// delayedCloser is a struct that makes sure a subject channel is closed at some
+// point, either after a delay or immediately.
+type delayedCloser struct {
+	subject chan<- struct{}
+	timeout time.Duration
+	once    sync.Once
+}
+
+// newDelayedCloser creates a new delayed closer for the given subject channel.
+func newDelayedCloser(subject chan<- struct{},
+	timeout time.Duration) *delayedCloser {
+
+	return &delayedCloser{
+		subject: subject,
+		timeout: timeout,
+	}
+}
+
+// closeEventually closes the subject channel after the configured timeout or
+// immediately if the quit channel is closed.
+func (t *delayedCloser) closeEventually(quit chan struct{}) {
+	go func() {
+		defer t.closeNow()
+
+		select {
+		case <-time.After(t.timeout):
+		case <-quit:
+		}
+	}()
+}
+
+// closeNow immediately closes the subject channel. This can safely be called
+// multiple times as it will only attempt to close the channel at most once.
+func (t *delayedCloser) closeNow() {
+	t.once.Do(func() {
+		close(t.subject)
+	})
 }

--- a/query.go
+++ b/query.go
@@ -4,11 +4,11 @@ package neutrino
 
 import (
 	"fmt"
-	"github.com/davecgh/go-spew/spew"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/gcash/bchd/blockchain"
 	"github.com/gcash/bchd/chaincfg/chainhash"
 	"github.com/gcash/bchd/wire"
@@ -1447,7 +1447,7 @@ func (s *ChainService) sendTransaction(tx *wire.MsgTx, options ...QueryOption) e
 		// the other peer must query its own state to determine whether
 		// it should accept the transaction.
 		append(
-			[]QueryOption{Timeout(time.Millisecond * 500)},
+			[]QueryOption{Timeout(s.broadcastTimeout)},
 			options...,
 		)...,
 	)

--- a/rescan.go
+++ b/rescan.go
@@ -6,12 +6,12 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/gcash/bchd/chaincfg"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/gcash/bchd/btcjson"
+	"github.com/gcash/bchd/chaincfg"
 	"github.com/gcash/bchd/chaincfg/chainhash"
 	"github.com/gcash/bchd/rpcclient"
 	"github.com/gcash/bchd/txscript"
@@ -522,6 +522,7 @@ func rescan(chain ChainSource, options ...RescanOption) error {
 			curHeader = header
 			curStamp.Hash = header.BlockHash()
 			curStamp.Height++
+			curStamp.Timestamp = header.Timestamp
 		}
 
 		log.Tracef("Rescan got block %d (%s)", curStamp.Height,


### PR DESCRIPTION
https://github.com/lightninglabs/neutrino/pull/194
```
Previously PersisToDisk is an option to GetCFilter.
The problem is that the option is not working well with the in-memory
FilterCache. The biggest problem is that if there are two calls of
GetCFilter, the first one without the PersistToDisk option, and the second
one with the PersistToDisk option, the second one returns the filter from
the cache and doesn't write it persistently to the disk.
Consequently, if a filter was already queried, there is no way to write it
to disk. So for instance if a neutrino user (mainly lnd) is closed before
it is fully synchronized, it need to re-download all the filters when it
runs again.
When handling the PersistToDisk in the ChainService itself, the caller of
NewChainService decides in _one place_ if the filters need to be stored
in the disk, and that will not depend on the order of calls to
GetCFilter.
```